### PR TITLE
Do not export `process.env`

### DIFF
--- a/.changeset/brown-dingos-try.md
+++ b/.changeset/brown-dingos-try.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/spex": patch
+---
+
+Replace `process.env` in final builds, to prevent the app to crash.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zazuko/spex",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zazuko/spex",
-      "version": "0.1.20",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.7.14",

--- a/vite.config.js
+++ b/vite.config.js
@@ -51,6 +51,9 @@ export default defineConfig({
   ],
   define: {
     global: 'window',
+    'process.env': {
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Right now, when the umd file is build, it's including references to `process.env.NODE_ENV`, and this is making the app crash if we try to load it in the browser.

The Trifid plugin cannot be upgraded because of this issue: https://github.com/zazuko/trifid/pull/400#issuecomment-2163186945

This PR is trying to solve this.