### PR TITLE
Fix missing index.html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zazuko/spex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zazuko/spex",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.7.14",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en" class="h-screen">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="description" content="SPARQL Endpoints Explorer" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/style.css" />
+    <title>SPEX</title>
+  </head>
+
+  <body class="h-full text-gray-700 dark:text-gray-50">
+    <noscript>
+      <strong
+        >We're sorry but SPEX doesn't work properly without JavaScript enabled.
+        Please enable it to continue.</strong
+      >
+    </noscript>
+    <div id="app" class="h-full"></div>
+    <script src="/spex.umd.cjs"></script>
+    <script type="text/javascript">
+      //<![CDATA[
+      window.onload = function () {
+        // Where to mount the SPEX app
+        const mountPoint = document.getElementById("app");
+
+        // Default options
+        const options = {
+          sparqlEndpoint: null,
+          url: null,
+          user: null,
+          password: null,
+          graph: null,
+          prefixes: [],
+          forceIntrospection: false,
+        };
+
+        // Parse query parameters and update options
+        const hash = window.location.hash.split("?");
+        if (hash.length > 1) {
+          const params = new URLSearchParams(hash[1]);
+
+          // Update options based on query parameters
+          options.sparqlEndpoint =
+            params.get("sparqlEndpoint") || options.sparqlEndpoint;
+          options.graph = params.get("namedGraph") || options.graph;
+          options.forceIntrospection =
+            params.get("forceIntrospection") === "true";
+          options.user = params.get("user") || options.user;
+          options.password = params.get("password") || options.password;
+          options.url = params.get("url") || options.url;
+
+          // Handle multiple prefixes
+          const prefixKeys = params.getAll("prefixes");
+          options.prefixes = prefixKeys.map((p) => {
+            const [prefix, namespace] = p.split(":");
+            return { prefix, namespace };
+          });
+        }
+
+        window.spex.render(mountPoint, options);
+      };
+      //]]>
+    </script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -85,4 +85,5 @@ export default defineConfig({
       fileName: 'spex'
     }
   },
+  publicDir: '../public',
 })


### PR DESCRIPTION
This is still not 100% working as it should.
Contributions are welcome!

Running `npm run serve` works well.
The thing, is that the `index.html` file was not generated anymore in the `dist` directory.

I've done something which is still WIP in this PR ; if someone has a better way to fix this or want to take over this, please do!

To try the built version:

```sh
rm -r dist # to make sure to start from a clean base
npm run build
npx serve dist
```

It is important that the dist directory contains the following files:
- `spex.js`
- `spex.umd.cjs`
- `style.css`

And to fix the issue we have, it should also contain:
- `index.html`
- `favicon.ico`

and any relevant files.