### PR TITLE
build: separate app and lib configs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,10 @@ jobs:
         run: npm ci
 
       - name: Build the app
-        run: npm run build
+        run: npm run build:app
+
+      - name: Build in lib mode
+        run: npm run build:lib
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
 
       - name: Build the app
-        run: npm run build
+        run: npm run build:app
 
       - name: Configure CNAME
         run: echo spex.zazuko.com > dist/CNAME

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@vue/eslint-config-standard": "^8.0.1",
     "@vue/eslint-config-typescript": "^11.0.3",
     "autoprefixer": "^10.4.14",
-    "esbuild": "^0.20",
     "eslint": "^8.42.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "serve": "vite",
-    "build": "vite build",
+    "build:app": "vite build",
+    "build:lib": "vite build -c vite.umd.config.js",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
-    "prepack": "npm run build",
+    "prepack": "npm run build:lib",
     "release": "changeset publish"
   },
   "main": "dist/spex.js",
@@ -48,6 +49,7 @@
     "@vue/eslint-config-standard": "^8.0.1",
     "@vue/eslint-config-typescript": "^11.0.3",
     "autoprefixer": "^10.4.14",
+    "esbuild": "^0.20",
     "eslint": "^8.42.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-node": "^11.1.0",

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -2,8 +2,10 @@
 
 import { register } from 'register-service-worker'
 
+const baseUrl = process.env.BASE_URL || ''
+
 if (process.env.NODE_ENV === 'production') {
-  register(`${process.env.BASE_URL}service-worker.js`, {
+  register(`${baseUrl}/sw.js`, {
     ready() {
       console.log(
         'App is being served from cache by a service worker.\n' +

--- a/src/views/ShaclEditor.vue
+++ b/src/views/ShaclEditor.vue
@@ -52,8 +52,8 @@ import { Splitpanes, Pane } from 'splitpanes'
 import 'splitpanes/dist/splitpanes.css'
 import '@rdfjs-elements/rdf-editor'
 import rdfEnvironment from '@zazuko/env/web'
-import { tablesFromSHACL } from '../shacl.js'
-import { rdf, sh } from '../namespace.js'
+import { tablesFromSHACL } from '../shacl'
+import { rdf, sh } from '../namespace'
 import ResourceCard from '../components/ResourceCard.vue'
 
 const formats = [...parsers.keys()]

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite'
 import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill'
-import rollupNodePolyFill from 'rollup-plugin-node-polyfills'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
 
@@ -73,16 +72,6 @@ export default defineConfig({
   },
   build: {
     outDir: '../dist',
-    sourcemap: true,
-    rollupOptions: {
-      plugins: [
-        rollupNodePolyFill(),
-      ],
-    },
-    lib: {
-      entry: 'index.ts',
-      name: 'spex',
-      fileName: 'spex'
-    }
-  },
+    emptyOutDir: true,
+  }
 })

--- a/vite.umd.config.js
+++ b/vite.umd.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import rollupNodePolyFill from 'rollup-plugin-node-polyfills'
+import config from './vite.config.js'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  ...config,
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true,
+    sourcemap: true,
+    rollupOptions: {
+      plugins: [
+        rollupNodePolyFill(),
+      ],
+    },
+    lib: {
+      entry: 'index.ts',
+      name: 'spex',
+      fileName: 'spex'
+    }
+  },
+})


### PR DESCRIPTION
The lib mode did not work well for the GiHub Pages deployment. Hence, I separated the builds so that web deployment is standard vite build and the NPM package will be the UMD we had until now